### PR TITLE
Temporary fix for broken radion buttons.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -295,7 +295,9 @@ function App() {
 		const radButtons = document.getElementsByTagName("input") 
 		for (let i = 0; i < radButtons.length; i++) {
 			if (radButtons[i].value === event.target.value) {
-				radButtons[i].className = "radio animated heartBeat";	
+				// radButtons[i].className = "radio animated heartBeat";	
+				radButtons[i].className = "radio";	
+
 			} else {
 				radButtons[i].className = "radio";	
 			}


### PR DESCRIPTION
On 28/2/20, radio buttons were broken for some reason. They were no longer blue in color.  And when you clicked one, it disappeared from view.  Temporary fix is to remove the animation class on the <input> element.  I will troubleshoot further later.